### PR TITLE
Add support for build_runner before running test

### DIFF
--- a/.github/workflows/run-tests-on-pull-request.yml
+++ b/.github/workflows/run-tests-on-pull-request.yml
@@ -30,5 +30,8 @@ jobs:
     - name: Get dependencies
       run: flutter pub get
 
+    - name: Run Build Runner
+      run: dart pub run build_runner build --delete-conflicting-outputs
+
     - name: Run Tests
       run: flutter test


### PR DESCRIPTION
Fix the failing CI workflow by adding `build_runner` step before running test. Closes #20 